### PR TITLE
docs: quote scoped opencode plugin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Give OpenCode long-term memory that survives context wipes, session restarts, an
 OpenCode installs the Honcho plugin and adds it to your global OpenCode config.
 
 ```bash
-opencode plugin @honcho-ai/opencode-honcho --global
+opencode plugin "@honcho-ai/opencode-honcho" --global
 ```
 
 To update an existing plugin install:
 
 ```bash
-opencode plugin @honcho-ai/opencode-honcho --force
+opencode plugin "@honcho-ai/opencode-honcho" --force
 ```
 
 This command expects the `opencode` CLI to already be installed and available on your `PATH`.


### PR DESCRIPTION
- Wrapped name of plugin in quotes for cleaner install. 
  - works good cross platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line examples in README to properly format the plugin identifier with quotation marks in install and update commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->