### PR TITLE
fix: inject cached hybrid memory every turn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1332,11 +1332,18 @@ export const createHonchoRuntimePlugin =
         const query = extractPromptQuery(input) || state.lastPromptQuery || ""
         const trimmedQuery = query.trim()
         const hasQuery = trimmedQuery.length > 0
-        const shouldRefreshStable = shouldInjectStableContext(state, INTERNAL_CONTEXT_REFRESH)
+        const promptIsTrivial = hasQuery && shouldSkipContextRetrieval(trimmedQuery, INTERNAL_CONTEXT_REFRESH)
+        if (promptIsTrivial) {
+          return
+        }
+        const shouldRefreshStable = !hasQuery && shouldInjectStableContext(state, INTERNAL_CONTEXT_REFRESH)
+        const shouldInjectCachedStable = hasQuery
         const shouldRefreshPrompt =
           hasQuery &&
-          !shouldSkipContextRetrieval(trimmedQuery, INTERNAL_CONTEXT_REFRESH) &&
           (handle.config.recallMode === "context" || handle.config.recallMode === "hybrid")
+        if (!shouldRefreshStable && !shouldInjectCachedStable && !shouldRefreshPrompt) {
+          return
+        }
         await withRuntime(input, async (runtime) => {
           const state = getState(deriveSessionStateKey(runtime))
           if (!state.stableContext || shouldRefreshStable) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ type SessionState = {
   stableContext: string | null
   cachedPromptContext: string | null
   lastInjectedContext: string | null
+  lastPromptQuery: string | null
   lastStableContextRefreshAt: number | null
   recentConclusions: string[]
   conclusionFingerprints: Set<string>
@@ -917,6 +918,7 @@ const createSessionState = (): SessionState => ({
   stableContext: null,
   cachedPromptContext: null,
   lastInjectedContext: null,
+  lastPromptQuery: null,
   lastStableContextRefreshAt: null,
   recentConclusions: [],
   conclusionFingerprints: new Set<string>(),
@@ -1310,6 +1312,7 @@ export const createHonchoRuntimePlugin =
         await withRuntime(input, async (runtime) => {
           const state = getState(deriveSessionStateKey(runtime))
           state.promptCount += 1
+          state.lastPromptQuery = message
           await captureMessage(runtime, runtime.userPeer, message, {
             source: "chat.message",
             sessionId: runtime.sessionId,
@@ -1325,30 +1328,28 @@ export const createHonchoRuntimePlugin =
         if (handle.config.recallMode === "tools" || !hasConfiguredAuth(handle.config)) {
           return
         }
-        const query = extractPromptQuery(input)
+        const state = getState(deriveSessionStateKey(handle))
+        const query = extractPromptQuery(input) || state.lastPromptQuery || ""
         const trimmedQuery = query.trim()
         const hasQuery = trimmedQuery.length > 0
-        const state = getState(deriveSessionStateKey(handle))
-        const shouldInjectStable = !hasQuery && shouldInjectStableContext(state, INTERNAL_CONTEXT_REFRESH)
-        const shouldSkip =
-          (hasQuery && shouldSkipContextRetrieval(trimmedQuery, INTERNAL_CONTEXT_REFRESH)) ||
-          (!hasQuery && !shouldInjectStable)
-        if (shouldSkip) {
-          return
-        }
+        const shouldRefreshStable = shouldInjectStableContext(state, INTERNAL_CONTEXT_REFRESH)
+        const shouldRefreshPrompt =
+          hasQuery &&
+          !shouldSkipContextRetrieval(trimmedQuery, INTERNAL_CONTEXT_REFRESH) &&
+          (handle.config.recallMode === "context" || handle.config.recallMode === "hybrid")
         await withRuntime(input, async (runtime) => {
           const state = getState(deriveSessionStateKey(runtime))
-          if (!state.stableContext || shouldInjectStable) {
+          if (!state.stableContext || shouldRefreshStable) {
             const stableContextHydrated = await hydrateSessionStartContext(runtime, state)
             if (stableContextHydrated) {
               state.lastStableContextRefreshAt = Date.now()
             }
-            if (shouldInjectStable && stableContextHydrated) {
+            if (shouldRefreshStable && stableContextHydrated) {
               state.promptCount = 0
             }
           }
           const promptContext =
-            hasQuery && (runtime.config.recallMode === "context" || runtime.config.recallMode === "hybrid")
+            shouldRefreshPrompt
               ? await refreshPromptContext(runtime, state, trimmedQuery)
               : null
           const compiledSections = [state.stableContext, promptContext].filter(

--- a/tests/context-injection.test.js
+++ b/tests/context-injection.test.js
@@ -180,6 +180,14 @@ const systemInput = (extra = {}) => ({
   ...extra,
 })
 
+const stableHydrationCallCount = (calls) =>
+  calls.filter(
+    (call) =>
+      (call.method === "GET" && /\/peers\/[^/]+\/context$/.test(call.pathname)) ||
+      (call.method === "GET" && /\/sessions\/[^/]+\/summaries$/.test(call.pathname)) ||
+      (call.method === "POST" && /\/peers\/[^/]+\/chat$/.test(call.pathname)),
+  ).length
+
 test("system transform injects Honcho memory when OpenCode provides no prompt text", async () => {
   await runWithHarness(async ({ hooks }) => {
     const output = { system: [] }
@@ -193,18 +201,19 @@ test("system transform injects Honcho memory when OpenCode provides no prompt te
   })
 })
 
-test("system transform skips repeated no-prompt injection inside the stable refresh window", async () => {
+test("system transform reuses stable context inside the stable refresh window", async () => {
   await runWithHarness(async ({ hooks, fetch }) => {
     const firstOutput = { system: [] }
     await hooks["experimental.chat.system.transform"](systemInput(), firstOutput)
-    const callCountAfterFirstInjection = fetch.calls.length
+    const hydrationCallCountAfterFirstInjection = stableHydrationCallCount(fetch.calls)
 
     const secondOutput = { system: [] }
     await hooks["experimental.chat.system.transform"](systemInput(), secondOutput)
 
     expect(firstOutput.system).toHaveLength(1)
-    expect(secondOutput.system).toEqual([])
-    expect(fetch.calls).toHaveLength(callCountAfterFirstInjection)
+    expect(secondOutput.system).toHaveLength(1)
+    expect(secondOutput.system[0]).toContain("The user prefers concise engineering analysis.")
+    expect(stableHydrationCallCount(fetch.calls)).toBe(hydrationCallCountAfterFirstInjection)
   })
 })
 
@@ -248,14 +257,43 @@ test("system transform retries no-prompt stable hydration when all context sourc
   }, { failStableHydration: true })
 })
 
-test("system transform still skips explicit trivial prompt text", async () => {
+test("system transform injects stable context for explicit trivial prompt text", async () => {
   await runWithHarness(async ({ hooks, fetch }) => {
     const output = { system: [] }
 
     await hooks["experimental.chat.system.transform"](systemInput({ query: "ok" }), output)
 
-    expect(output.system).toEqual([])
-    expect(fetch.calls).toHaveLength(0)
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).toContain("The user prefers concise engineering analysis.")
+    expect(
+      fetch.calls.some(
+        (call) => call.method === "GET" && /\/sessions\/[^/]+\/context$/.test(call.pathname),
+      ),
+    ).toBe(false)
+  })
+})
+
+test("system transform uses the latest chat message when OpenCode provides no prompt text", async () => {
+  await runWithHarness(async ({ hooks, fetch }) => {
+    const messageOutput = {
+      message: { time: { created: Date.now() } },
+      parts: [{ type: "text", text: "fix memory injection" }],
+    }
+    await hooks["chat.message"]({ sessionID: "ses-test" }, messageOutput)
+
+    const output = { system: [] }
+    await hooks["experimental.chat.system.transform"](systemInput(), output)
+
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).toContain("Prompt memory for memory-injection")
+    expect(
+      fetch.calls.some(
+        (call) =>
+          call.method === "GET" &&
+          /\/sessions\/[^/]+\/context$/.test(call.pathname) &&
+          call.search.get("search_query") === "memory-injection",
+      ),
+    ).toBe(true)
   })
 })
 

--- a/tests/context-injection.test.js
+++ b/tests/context-injection.test.js
@@ -201,7 +201,7 @@ test("system transform injects Honcho memory when OpenCode provides no prompt te
   })
 })
 
-test("system transform reuses stable context inside the stable refresh window", async () => {
+test("system transform skips repeated no-prompt injection inside the stable refresh window", async () => {
   await runWithHarness(async ({ hooks, fetch }) => {
     const firstOutput = { system: [] }
     await hooks["experimental.chat.system.transform"](systemInput(), firstOutput)
@@ -211,8 +211,7 @@ test("system transform reuses stable context inside the stable refresh window", 
     await hooks["experimental.chat.system.transform"](systemInput(), secondOutput)
 
     expect(firstOutput.system).toHaveLength(1)
-    expect(secondOutput.system).toHaveLength(1)
-    expect(secondOutput.system[0]).toContain("The user prefers concise engineering analysis.")
+    expect(secondOutput.system).toEqual([])
     expect(stableHydrationCallCount(fetch.calls)).toBe(hydrationCallCountAfterFirstInjection)
   })
 })
@@ -257,19 +256,14 @@ test("system transform retries no-prompt stable hydration when all context sourc
   }, { failStableHydration: true })
 })
 
-test("system transform injects stable context for explicit trivial prompt text", async () => {
+test("system transform still skips explicit trivial prompt text", async () => {
   await runWithHarness(async ({ hooks, fetch }) => {
     const output = { system: [] }
 
     await hooks["experimental.chat.system.transform"](systemInput({ query: "ok" }), output)
 
-    expect(output.system).toHaveLength(1)
-    expect(output.system[0]).toContain("The user prefers concise engineering analysis.")
-    expect(
-      fetch.calls.some(
-        (call) => call.method === "GET" && /\/sessions\/[^/]+\/context$/.test(call.pathname),
-      ),
-    ).toBe(false)
+    expect(output.system).toEqual([])
+    expect(fetch.calls).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
## Summary

- Reuse cached stable Honcho memory for eligible non-trivial prompts instead of only injecting during stable-context refreshes.
- Fall back to the latest `chat.message` text when `experimental.chat.system.transform` does not include prompt text, so hybrid recall can still use the current user request as the query.
- Preserve existing trivial-prompt behavior: prompts like `ok` still skip memory injection and prompt-specific retrieval.

## Why

OpenCode's `experimental.chat.system.transform` hook may not include the current prompt text. The previous logic coupled "should refresh Honcho memory" with "should inject already-cached memory", so cached memory could be skipped even when it was available.

This separates refresh cadence from injection: Honcho API refreshes remain throttled, while cached stable memory can still be included for meaningful prompts.

## Testing

- `bun run test`

## Note

This PR was LLM-assisted.
