### PR TITLE
feat: export transcripts with honcho memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ If OpenCode is running in Docker or another remote environment, `localhost` may 
 | `/honcho:status` | Show effective Honcho status for the current OpenCode project, including live workspace and session names when available |
 | `/honcho:settings` | Show effective config values and config paths |
 | `/honcho:config` | Edit shared Honcho fields in `~/.honcho/config.json` |
+| `/honcho:transcript` | Export the current transcript with injected Honcho memory blocks |
 
 ## Agent Tools
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ type SessionState = {
   stableContext: string | null
   cachedPromptContext: string | null
   lastInjectedContext: string | null
+  lastPromptQuery: string | null
+  lastPromptMessageId: string | null
   lastStableContextRefreshAt: number | null
   recentConclusions: string[]
   conclusionFingerprints: Set<string>
@@ -96,9 +98,33 @@ type PeerTopology = {
 const SETTINGS_DIR_NAME = ".opencode"
 const SHARED_SETTINGS_DIR_NAME = ".honcho"
 const SHARED_SETTINGS_FILE_NAME = "config.json"
+const MEMORY_SNAPSHOT_FILE_NAME = "opencode-memory-snapshot.json"
 const LEGACY_API_KEY_FIELD = "apiKey"
 const RUNTIME_SERVICE = "opencode-honcho"
 const MAX_RECENT_CONCLUSIONS = 8
+
+type MemorySnapshotInjection = {
+  updatedAt: string
+  messageId?: string
+  query: string
+  context: string
+}
+
+type MemorySnapshotEntry = {
+  updatedAt: string
+  workspace: string
+  sessionId: string
+  sessionKey: string
+  recallMode: RecallMode
+  context: string
+  history: MemorySnapshotInjection[]
+}
+
+type MemorySnapshotFile = {
+  version: 1
+  latestSessionId?: string
+  entries: Record<string, MemorySnapshotEntry>
+}
 
 const DEFAULT_SETTINGS: HonchoSettings = {
   apiKey: "",
@@ -575,6 +601,8 @@ const sharedGlobalSettingsPath = () => {
   return path.join(userHomeDir(), SHARED_SETTINGS_DIR_NAME, SHARED_SETTINGS_FILE_NAME)
 }
 
+const memorySnapshotPath = () => path.join(userHomeDir(), SHARED_SETTINGS_DIR_NAME, MEMORY_SNAPSHOT_FILE_NAME)
+
 const readJsonFile = async (configPath: string) => {
   try {
     return JSON.parse(await readFile(configPath, "utf-8")) as Record<string, unknown>
@@ -587,6 +615,48 @@ const readJsonFile = async (configPath: string) => {
 }
 
 const readConfigFile = async (configPath: string) => normalizedRawSettings((await readJsonFile(configPath)) ?? {})
+
+const readMemorySnapshotFile = async (): Promise<MemorySnapshotFile> => {
+  const parsed = await readJsonFile(memorySnapshotPath())
+  if (!parsed || !isRecord(parsed.entries)) {
+    return { version: 1, entries: {} }
+  }
+  return parsed as MemorySnapshotFile
+}
+
+const writeMemorySnapshot = async (
+  runtime: RuntimeHandle,
+  injection: { messageId?: string; query: string; context: string },
+) => {
+  const snapshot = await readMemorySnapshotFile()
+  const updatedAt = new Date().toISOString()
+  const current = snapshot.entries[runtime.sessionId]
+  const history = [
+    ...(current?.history ?? []).filter(
+      (item) => !injection.messageId || item.messageId !== injection.messageId,
+    ),
+    {
+      updatedAt,
+      ...(injection.messageId ? { messageId: injection.messageId } : {}),
+      query: injection.query,
+      context: injection.context,
+    },
+  ].slice(-200)
+
+  snapshot.latestSessionId = runtime.sessionId
+  snapshot.entries[runtime.sessionId] = {
+    updatedAt,
+    workspace: runtime.workspaceId,
+    sessionId: runtime.sessionId,
+    sessionKey: runtime.sessionKey,
+    recallMode: runtime.config.recallMode,
+    context: injection.context,
+    history,
+  }
+
+  await mkdir(path.dirname(memorySnapshotPath()), { recursive: true })
+  await writeFile(memorySnapshotPath(), `${JSON.stringify(snapshot, null, 2)}\n`, "utf-8")
+}
 
 const envSettings = (): Record<string, unknown> => ({
   apiKey: process.env.HONCHO_API_KEY || "",
@@ -917,6 +987,8 @@ const createSessionState = (): SessionState => ({
   stableContext: null,
   cachedPromptContext: null,
   lastInjectedContext: null,
+  lastPromptQuery: null,
+  lastPromptMessageId: null,
   lastStableContextRefreshAt: null,
   recentConclusions: [],
   conclusionFingerprints: new Set<string>(),
@@ -1310,6 +1382,8 @@ export const createHonchoRuntimePlugin =
         await withRuntime(input, async (runtime) => {
           const state = getState(deriveSessionStateKey(runtime))
           state.promptCount += 1
+          state.lastPromptQuery = message
+          state.lastPromptMessageId = typeof input.messageID === "string" ? input.messageID : null
           await captureMessage(runtime, runtime.userPeer, message, {
             source: "chat.message",
             sessionId: runtime.sessionId,
@@ -1359,6 +1433,18 @@ export const createHonchoRuntimePlugin =
           }
           const compiled = compiledSections.join("\n\n")
           state.lastInjectedContext = compiled
+          try {
+            await writeMemorySnapshot(runtime, {
+              messageId: state.lastPromptMessageId ?? undefined,
+              query: trimmedQuery || state.lastPromptQuery || "",
+              context: compiled,
+            })
+          } catch (error) {
+            await log("warn", "Failed to write Honcho memory transcript snapshot.", {
+              sessionId: runtime.sessionId,
+              message: error instanceof Error ? error.message : String(error),
+            })
+          }
           output.system = output.system || []
           output.system.push(
             `## Honcho Memory\nUse this as persistent project and user memory. Prefer it over guessing, but only mention it when relevant to the current task.\n\n${compiled}`,

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -7,6 +7,7 @@ const PACKAGE_ID = "@honcho-ai/opencode-honcho"
 const DEFAULT_BASE_URL = "https://api.honcho.dev"
 const SHARED_SETTINGS_DIR_NAME = ".honcho"
 const SHARED_SETTINGS_FILE_NAME = "config.json"
+const MEMORY_SNAPSHOT_FILE_NAME = "opencode-memory-snapshot.json"
 
 const SHARED_CONFIG_PRESETS: Record<string, readonly string[]> = {
   recallmode: ["hybrid", "context", "tools"],
@@ -40,11 +41,75 @@ type GlobalSettings = {
   }
 }
 
+type MemorySnapshotInjection = {
+  updatedAt?: string
+  messageId?: string
+  query?: string
+  context?: string
+}
+
+type MemorySnapshotEntry = {
+  updatedAt?: string
+  workspace?: string
+  sessionId?: string
+  sessionKey?: string
+  recallMode?: string
+  context?: string
+  history?: MemorySnapshotInjection[]
+}
+
+type MemorySnapshot = {
+  latestSessionId?: string
+  entries?: Record<string, MemorySnapshotEntry>
+}
+
+type TranscriptSession = {
+  id: string
+  title?: string
+  time?: {
+    created?: number
+    updated?: number
+  }
+}
+
+type TranscriptMessage = {
+  id: string
+  role: "user" | "assistant"
+  agent?: string
+  modelID?: string
+  time?: {
+    created?: number
+    completed?: number
+  }
+}
+
+type TranscriptPart = {
+  type: string
+  text?: string
+  synthetic?: boolean
+  ignored?: boolean
+  tool?: string
+  state?: {
+    status?: string
+    input?: unknown
+    output?: string
+    error?: string
+  }
+}
+
+type TranscriptMessageWithParts = {
+  info: TranscriptMessage
+  parts: readonly TranscriptPart[]
+}
+
 const globalSettingsPath = () =>
   path.join(process.env.HOME || process.env.USERPROFILE || homedir(), SHARED_SETTINGS_DIR_NAME, SHARED_SETTINGS_FILE_NAME)
 
 const sharedConfigPath = () =>
   path.join(process.env.HOME || process.env.USERPROFILE || homedir(), SHARED_SETTINGS_DIR_NAME, SHARED_SETTINGS_FILE_NAME)
+
+const memorySnapshotPath = () =>
+  path.join(process.env.HOME || process.env.USERPROFILE || homedir(), SHARED_SETTINGS_DIR_NAME, MEMORY_SNAPSHOT_FILE_NAME)
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -82,6 +147,18 @@ const readSharedConfig = async (): Promise<Record<string, unknown> | null> => {
       throw new Error(`${configPath} must contain a JSON object at the top level.`)
     }
     return parsed
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null
+    }
+    throw error
+  }
+}
+
+const readMemorySnapshot = async (): Promise<MemorySnapshot | null> => {
+  try {
+    const parsed = JSON.parse(await readFile(memorySnapshotPath(), "utf-8"))
+    return isRecord(parsed) ? (parsed as MemorySnapshot) : null
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return null
@@ -236,6 +313,97 @@ const settingsMessage = (settings: GlobalSettings) => {
     `Recall mode: ${host.recallMode || "hybrid"}`,
     `Session strategy: ${host.sessionStrategy || "per-directory"}`,
   ].join("\n")
+}
+
+const titleCase = (value: string) =>
+  value ? `${value.slice(0, 1).toUpperCase()}${value.slice(1)}` : value
+
+const safeFileSegment = (value: string) => value.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "session"
+
+const transcriptPath = (sessionID: string, directory: string) =>
+  path.join(directory, `session-${safeFileSegment(sessionID).slice(0, 8)}-honcho-memory.md`)
+
+const memoryByMessageId = (entry?: MemorySnapshotEntry) => {
+  const pairs = (entry?.history ?? [])
+    .filter((item) => typeof item.messageId === "string" && item.messageId && typeof item.context === "string")
+    .map((item) => [item.messageId as string, item.context as string] as const)
+  return new Map(pairs)
+}
+
+const formatTranscriptPart = (part: TranscriptPart) => {
+  if (part.type === "text" && !part.synthetic && !part.ignored && part.text) {
+    return `${part.text}\n\n`
+  }
+  if (part.type === "tool" && part.tool) {
+    return `**Tool: ${part.tool}**\n\n`
+  }
+  return ""
+}
+
+const formatAssistantHeader = (message: TranscriptMessage) => {
+  const duration =
+    message.time?.completed && message.time.created
+      ? ` · ${((message.time.completed - message.time.created) / 1000).toFixed(1)}s`
+      : ""
+  const metadata = [message.agent ? titleCase(message.agent) : null, message.modelID].filter(Boolean).join(" · ")
+  return metadata ? `## Assistant (${metadata}${duration})\n\n` : "## Assistant\n\n"
+}
+
+const formatTranscriptMessage = (message: TranscriptMessageWithParts, memory: Map<string, string>) => {
+  const body = message.parts.map(formatTranscriptPart).join("")
+  if (message.info.role === "user") {
+    const context = memory.get(message.info.id)
+    return [`## User\n\n${body}`, context ? `### Injected Honcho Memory\n\n${context}\n\n` : ""].join("")
+  }
+  return `${formatAssistantHeader(message.info)}${body}`
+}
+
+const formatMemoryTranscript = (
+  session: TranscriptSession,
+  messages: readonly TranscriptMessageWithParts[],
+  memory: Map<string, string>,
+) => [
+  "# Honcho Memory Transcript",
+  "",
+  `**Session ID:** ${session.id}`,
+  `**Created:** ${new Date(session.time?.created ?? Date.now()).toLocaleString()}`,
+  `**Updated:** ${new Date(session.time?.updated ?? Date.now()).toLocaleString()}`,
+  "",
+  "---",
+  "",
+  ...messages.flatMap((message) => [formatTranscriptMessage(message, memory).trimEnd(), "---", ""]),
+].join("\n")
+
+const loadTranscriptSession = async (api: Parameters<TuiPlugin>[0], sessionID: string): Promise<TranscriptSession> => {
+  const result = await api.client.session.get({ sessionID })
+  if (result.error) {
+    throw new Error("Could not load the current OpenCode session.")
+  }
+  return result.data
+}
+
+const loadTranscriptMessages = async (
+  api: Parameters<TuiPlugin>[0],
+  sessionID: string,
+): Promise<TranscriptMessageWithParts[]> => {
+  const result = await api.client.session.messages({ sessionID })
+  if (result.error) {
+    throw new Error("Could not load OpenCode session messages.")
+  }
+  return result.data.map((message) => ({ info: message.info, parts: message.parts }))
+}
+
+const exportMemoryTranscript = async (api: Parameters<TuiPlugin>[0], sessionID: string) => {
+  const snapshot = await readMemorySnapshot()
+  const session = await loadTranscriptSession(api, sessionID)
+  const messages = await loadTranscriptMessages(api, sessionID)
+  const filePath = transcriptPath(sessionID, api.state.path.directory || api.state.path.worktree || process.cwd())
+  await writeFile(
+    filePath,
+    `${formatMemoryTranscript(session, messages, memoryByMessageId(snapshot?.entries?.[sessionID]))}\n`,
+    "utf-8",
+  )
+  return filePath
 }
 
 const saveSettings = async (partial: Partial<GlobalSettings>) => {
@@ -502,6 +670,39 @@ const openModeDialog = async (api: Parameters<TuiPlugin>[0]) => {
   )
 }
 
+const openTranscriptExportDialog = async (api: Parameters<TuiPlugin>[0]) => {
+  const sessionID =
+    api.route?.current?.name === "session" && typeof api.route.current.params?.sessionID === "string"
+      ? api.route.current.params.sessionID
+      : undefined
+  if (!sessionID) {
+    api.ui.dialog.replace(() =>
+      api.ui.DialogAlert({
+        title: "Honcho transcript export unavailable",
+        message: "Open a session before exporting a Honcho memory transcript.",
+      }),
+    )
+    return
+  }
+
+  try {
+    const filePath = await exportMemoryTranscript(api, sessionID)
+    api.ui.dialog.replace(() =>
+      api.ui.DialogAlert({
+        title: "Honcho transcript exported",
+        message: `Saved transcript with injected memory to ${filePath}`,
+      }),
+    )
+  } catch (error) {
+    api.ui.dialog.replace(() =>
+      api.ui.DialogAlert({
+        title: "Honcho transcript export failed",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
 const openSetupDialog = (api: Parameters<TuiPlugin>[0]) => {
   api.ui.dialog.replace(() =>
     api.ui.DialogSelect({
@@ -577,6 +778,19 @@ const buildCommands = (api: Parameters<TuiPlugin>[0]) => [
       void openModeDialog(api)
     },
   },
+  {
+    title: "Honcho Transcript",
+    value: "honcho.transcript",
+    description: "Export the current transcript with injected Honcho memory blocks",
+    category: "Honcho",
+    slash: {
+      name: "honcho:transcript",
+      aliases: ["honcho:export-transcript"],
+    },
+    onSelect: () => {
+      void openTranscriptExportDialog(api)
+    },
+  },
 ]
 
 const tui: TuiPlugin = async (api) => {
@@ -593,6 +807,7 @@ export const __testing = {
   deriveLiveStatus,
   normalizeSettings,
   modeEditableFieldPaths,
+  memoryByMessageId,
   readSharedConfig,
   resolveSharedConfigField,
   saveSettings,
@@ -600,6 +815,8 @@ export const __testing = {
   sharedConfigPath,
   sharedConfigPresetOptions,
   statusMessage,
+  formatMemoryTranscript,
+  transcriptPath,
   validateCloudApiKey,
 }
 

--- a/tests/context-injection.test.js
+++ b/tests/context-injection.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import os from "node:os"
 import path from "node:path"
-import { mkdtemp } from "node:fs/promises"
+import { mkdtemp, readFile } from "node:fs/promises"
 
 import { createHonchoRuntimePlugin } from "../dist/index.js"
 
@@ -169,7 +169,7 @@ const runWithHarness = async (action, fetchOptions) => {
       HONCHO_BASE_URL: undefined,
     }, async () => {
       const hooks = await createPluginHarness(rootDir)
-      return action({ hooks, fetch })
+      return action({ hooks, fetch, homeDir })
     }),
   )
 }
@@ -276,5 +276,18 @@ test("system transform injects prompt-specific context for non-trivial prompt te
           call.search.get("search_query") === "memory-injection",
       ),
     ).toBe(true)
+  })
+})
+
+test("system transform writes injected memory snapshot for transcript export", async () => {
+  await runWithHarness(async ({ hooks, homeDir }) => {
+    const output = { system: [] }
+
+    await hooks["experimental.chat.system.transform"](systemInput({ query: "fix memory injection" }), output)
+
+    const snapshot = JSON.parse(await readFile(path.join(homeDir, ".honcho", "opencode-memory-snapshot.json"), "utf-8"))
+    expect(snapshot.latestSessionId).toBe("ses-test")
+    expect(snapshot.entries["ses-test"].context).toContain("Prompt memory for memory-injection")
+    expect(snapshot.entries["ses-test"].history.at(-1).query).toBe("fix memory injection")
   })
 })

--- a/tests/tui-behavior.test.js
+++ b/tests/tui-behavior.test.js
@@ -90,18 +90,53 @@ test("status and settings messages are distinct surfaces", () => {
   assert.notEqual(__testing.statusMessage(settings), __testing.settingsMessage(settings))
 })
 
-test("native TUI Honcho commands register slash aliases for setup, status, settings, and config", () => {
+test("native TUI Honcho commands register slash aliases for setup, status, settings, config, and transcript export", () => {
   const commands = __testing.buildCommands({})
   assert.deepEqual(commands.map((command) => command.value), [
     "honcho.setup",
     "honcho.status",
     "honcho.settings",
     "honcho.config",
+    "honcho.transcript",
   ])
   assert.deepEqual(
     commands.map((command) => command.slash?.name),
-    ["honcho:setup", "honcho:status", "honcho:settings", "honcho:config"],
+    ["honcho:setup", "honcho:status", "honcho:settings", "honcho:config", "honcho:transcript"],
   )
+  assert.deepEqual(commands.at(-1).slash?.aliases, ["honcho:export-transcript"])
+})
+
+test("memory transcript formatter inserts injected memory below matching user message", () => {
+  const memory = __testing.memoryByMessageId({
+    history: [
+      {
+        messageId: "msg-user",
+        context: "## Agent Work Context\n- Working on transcript export",
+      },
+    ],
+  })
+
+  const transcript = __testing.formatMemoryTranscript(
+    {
+      id: "ses_225d52ae4ffeqsr6jhw5Jmbqtt",
+      time: { created: 0, updated: 1000 },
+    },
+    [
+      {
+        info: { id: "msg-user", role: "user" },
+        parts: [{ type: "text", text: "What have we been working on lately?" }],
+      },
+      {
+        info: { id: "msg-assistant", role: "assistant" },
+        parts: [{ type: "text", text: "OpenCode Honcho memory." }],
+      },
+    ],
+    memory,
+  )
+
+  assert.match(transcript, /# Honcho Memory Transcript/)
+  assert.match(transcript, /### Injected Honcho Memory/)
+  assert.match(transcript, /Working on transcript export/)
 })
 
 test("honcho config only exposes top-level and hosts.opencode fields", () => {


### PR DESCRIPTION
## Summary
- Adds a `/honcho:transcript` TUI command, with `/honcho:export-transcript` as an alias, to write a markdown transcript for the current OpenCode session.
- Records the exact Honcho memory block appended by the system transform into `~/.honcho/opencode-memory-snapshot.json` so exports can show what memory was injected for each user message.
- Keeps this as a diagnostic/export surface only; it does not change memory retrieval or injection decisions.

## Testing
- `bun run check`
- `bun run test`

## Note
This is intended to make memory-injection behavior auditable before making further changes to the injection strategy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/honcho:transcript` command to export the current session transcript with Honcho memory blocks injected.

* **Tests**
  * Updated tests to validate memory snapshot persistence, transcript export functionality, and formatting of injected memory context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->