### PR TITLE
fix: use bare peerName for the user peer to match sibling plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -619,6 +619,14 @@ const currentUserName = () => "user"
 const deriveUserPeerId = (settings: Pick<HonchoSettings, "peerName">) =>
   normalizeId(settings.peerName || currentUserName())
 
+const assertDistinctUserAndAgentPeers = (userPeerId: string, rootAgentPeerId: string) => {
+  if (userPeerId === rootAgentPeerId) {
+    throw new Error(
+      `Invalid Honcho config: peerName and aiPeer both resolve to the peer id '${userPeerId}'; they must differ so user and agent memory stay separate.`,
+    )
+  }
+}
+
 const rootApiKey = (raw: Record<string, unknown>) => {
   const legacyApiKey = typeof raw[LEGACY_API_KEY_FIELD] === "string" ? expandEnv(raw[LEGACY_API_KEY_FIELD] as string) : ""
   return legacyApiKey
@@ -759,6 +767,7 @@ const deriveRuntimeHandle = async (
   const workspaceId = normalizeId(settings.workspace || "opencode")
   const userPeerId = deriveUserPeerId(settings)
   const rootAgentPeerId = normalizeId(settings.aiPeer || "opencode")
+  assertDistinctUserAndAgentPeers(userPeerId, rootAgentPeerId)
   const activeAgentPeerId = rootAgentPeerId
   const childAgentPeerId = null
   const parentAgentObserverPeerId = null
@@ -1671,6 +1680,7 @@ export const HonchoRuntimePlugin = createHonchoRuntimePlugin()
 export const __testing = {
   createSessionState,
   deriveUserPeerId,
+  assertDistinctUserAndAgentPeers,
   deriveSessionStateKey,
   extractCompletedAssistantMessage,
   honchoSdkImportPath: "@honcho-ai/sdk",

--- a/src/index.ts
+++ b/src/index.ts
@@ -616,6 +616,9 @@ const writeSettings = async (
 
 const currentUserName = () => "user"
 
+const deriveUserPeerId = (settings: Pick<HonchoSettings, "peerName">) =>
+  normalizeId(settings.peerName || currentUserName())
+
 const rootApiKey = (raw: Record<string, unknown>) => {
   const legacyApiKey = typeof raw[LEGACY_API_KEY_FIELD] === "string" ? expandEnv(raw[LEGACY_API_KEY_FIELD] as string) : ""
   return legacyApiKey
@@ -754,7 +757,7 @@ const deriveRuntimeHandle = async (
   const sessionId = extractSessionId(input)
   const repoName = path.basename(rootDir)
   const workspaceId = normalizeId(settings.workspace || "opencode")
-  const userPeerId = normalizeId(`user:${settings.peerName || currentUserName()}`)
+  const userPeerId = deriveUserPeerId(settings)
   const rootAgentPeerId = normalizeId(settings.aiPeer || "opencode")
   const activeAgentPeerId = rootAgentPeerId
   const childAgentPeerId = null
@@ -1667,6 +1670,7 @@ export const createHonchoRuntimePlugin =
 export const HonchoRuntimePlugin = createHonchoRuntimePlugin()
 export const __testing = {
   createSessionState,
+  deriveUserPeerId,
   deriveSessionStateKey,
   extractCompletedAssistantMessage,
   honchoSdkImportPath: "@honcho-ai/sdk",

--- a/tests/context-injection.test.js
+++ b/tests/context-injection.test.js
@@ -96,7 +96,7 @@ const createHonchoFetch = ({ failStableHydration = false } = {}) => {
       return jsonResponse({
         peer_id: peerId,
         target_id: null,
-        representation: peerId.startsWith("user-")
+        representation: peerId === "user"
           ? "The user prefers concise engineering analysis."
           : "The assistant is working on opencode-honcho.",
         peer_card: ["Keep changes narrowly scoped."],

--- a/tests/peer-collision.test.js
+++ b/tests/peer-collision.test.js
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+
+import { __testing } from "../dist/index.js"
+
+test("distinct user and agent peers are accepted", () => {
+  expect(() => __testing.assertDistinctUserAndAgentPeers("rui", "opencode")).not.toThrow()
+})
+
+test("colliding user and agent peers are rejected", () => {
+  expect(() => __testing.assertDistinctUserAndAgentPeers("opencode", "opencode")).toThrow(
+    /peerName and aiPeer both resolve to the peer id 'opencode'/,
+  )
+})

--- a/tests/peer-topology.test.js
+++ b/tests/peer-topology.test.js
@@ -5,7 +5,7 @@ import { __testing } from "../dist/index.js"
 test("root sessions keep user and root agent as peers", () => {
   const topology = __testing.buildPeerTopology({
     config: {},
-    userPeerId: "user:user",
+    userPeerId: "user",
     rootAgentPeerId: "opencode",
     activeAgentPeerId: "opencode",
     childAgentPeerId: null,
@@ -13,7 +13,7 @@ test("root sessions keep user and root agent as peers", () => {
   })
 
   expect(topology.sessionPeerConfigs).toEqual({
-    "user:user": { observeMe: true, observeOthers: false },
+    "user": { observeMe: true, observeOthers: false },
     opencode: { observeMe: true, observeOthers: true },
   })
   expect(topology.describedPeers.childAgentPeer).toBeNull()
@@ -23,7 +23,7 @@ test("root sessions keep user and root agent as peers", () => {
 test("classic peer model keeps delegated sessions on the Claude-style user and ai peers", () => {
   const topology = __testing.buildPeerTopology({
     config: {},
-    userPeerId: "user:user",
+    userPeerId: "user",
     rootAgentPeerId: "opencode",
     activeAgentPeerId: "opencode:reviewer",
     childAgentPeerId: "opencode:reviewer",
@@ -31,7 +31,7 @@ test("classic peer model keeps delegated sessions on the Claude-style user and a
   })
 
   expect(topology.sessionPeerConfigs).toEqual({
-    "user:user": { observeMe: true, observeOthers: false },
+    "user": { observeMe: true, observeOthers: false },
     opencode: { observeMe: true, observeOthers: true },
   })
   expect(topology.describedPeers.childAgentPeer).toBeNull()

--- a/tests/user-peer-id.test.js
+++ b/tests/user-peer-id.test.js
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+
+import { __testing } from "../dist/index.js"
+
+test("user peer id is the bare peerName with no prefix", () => {
+  expect(__testing.deriveUserPeerId({ peerName: "rui" })).toBe("rui")
+})
+
+test("user peer id falls back to the current user name when peerName is empty", () => {
+  expect(__testing.deriveUserPeerId({ peerName: "" })).toBe("user")
+})
+
+test("user peer id is normalised", () => {
+  expect(__testing.deriveUserPeerId({ peerName: "Rui Rei" })).toBe("rui-rei")
+})


### PR DESCRIPTION
Closes #22.

The user peer was derived as `user:${peerName}` (normalised to `user-<peerName>`), whereas the claude-honcho and hermes-honcho plugins use the bare `peerName`. In a shared workspace this split the user's memory into a separate `user-<peerName>` collection, so OpenCode never saw or contributed to what the other tools learned. This drops the prefix so the user peer matches the sibling plugins.

Added a regression test for the derivation and updated two fixtures that encoded the old convention. `bun test` (58 passing) and `tsc --noEmit` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the user peer ID format for more consistent peer handling across the app.
  * Added a fallback to the current username when no peer name is configured.
  * Prevented user and agent peers from resolving to the same identity, helping keep their data separate.
  * Improved peer name normalization for multi-word names and other common inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->