### PR TITLE
chore: Opencode Honcho 0.1.3 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.3
+
+- Add `hosts.opencode.removeUserPrefix` to control how the user peer id is derived. New installs use the bare `<peerName>` to match the sibling claude-honcho / hermes-honcho plugins, while existing installs default to the legacy `user-<peerName>` peer so previously accumulated memory is never orphaned on upgrade.
+- Enforce distinct user and agent peer ids to prevent collisions that would split memory across peers.
+- Refactoring and cleanup work.
+
 ## 0.1.2
 
 - Allow self-hosted and localhost Honcho setups to run without a Honcho API key.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/opencode-honcho",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Honcho memory integration for OpenCode",
   "license": "MIT",


### PR DESCRIPTION
Release **0.1.3**. Metadata only — version bump + changelog (matches the 0.1.2 release convention).

## Changes (2 files, +7 / −1)
- `package.json` — `0.1.2` → `0.1.3`
- `CHANGELOG.md` — new `0.1.3` section

## 0.1.3 changelog
- Add `hosts.opencode.removeUserPrefix` to control how the user peer id is derived. New installs use the bare `<peerName>` to match the sibling claude-honcho / hermes-honcho plugins, while existing installs default to the legacy `user-<peerName>` peer so previously accumulated memory is never orphaned on upgrade.
- Enforce distinct user and agent peer ids to prevent collisions that would split memory across peers.
- Refactoring and cleanup work.

## Covers (since 0.1.2)
- #24 — gate user-peer prefix on `hosts.opencode.removeUserPrefix` (+ collision guard)
- #25 — refactoring and cleanup

## Verification
- Fresh-install path → `removeUserPrefix: true`, bare `<peerName>` peer
- Upgrade path → `removeUserPrefix: false`, legacy `user-<peerName>` peer, existing config left unmodified
- `bun test` 63/63 on this code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control user peer identifier derivation.
  * Enhanced distinction between user and agent identifiers to prevent collisions.

* **Chores**
  * Version bumped to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->