### PR TITLE
fix: preserve peer id case when removeUserPrefix is true

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -219,7 +219,10 @@ export const honchoSessionKey = (
 
 export const deriveUserPeerId = (peerName: string, removeUserPrefix: boolean) => {
   const name = peerName.trim() || "user"
-  return removeUserPrefix ? normalizeId(name) : normalizeId(`user:${name}`)
+  // The sibling claude-honcho / hermes-honcho plugins use the peer name
+  // verbatim (no case folding), so removeUserPrefix=true must skip normalizeId
+  // to achieve real parity instead of silently lowercasing into a different peer.
+  return removeUserPrefix ? name : normalizeId(`user:${name}`)
 }
 
 export const resolveSessionPeerIds = (peerName: string, aiPeer: string, removeUserPrefix: boolean) => {


### PR DESCRIPTION
Closes [#29](https://github.com/plastic-labs/opencode-honcho/issues/29)

OpenCode's `removeUserPrefix: true` setting is supposed to make the user peer ID match the sibling `claude-honcho` plugin, but it still runs the name through a lowercase filter, so `"Stefano"` becomes `"stefano"`, a different, empty peer than the one Claude Code has been writing to for weeks.

This fix skips that lowercasing for the `removeUserPrefix: true` case, so the peer ID matches exactly what the sibling plugins use. The legacy `false` path (existing installs) is untouched.

Added two tests covering the case-preservation and a blank-name fallback. Full test suite passes (65/65), typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - User peer names are now preserved exactly as entered when the user prefix is removed.
  - Existing behavior remains unchanged when the user prefix is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->