### PR TITLE
fix: honor hosts.opencode.apiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Honor `hosts.opencode.apiKey` as an override of the root `apiKey`. Setup preserves a host-scoped key instead of copying or dropping it.
+
 ## 0.1.3
 
 - Add `hosts.opencode.removeUserPrefix` to control how the user peer id is derived. New installs use the bare `<peerName>` to match the sibling claude-honcho / hermes-honcho plugins, while existing installs default to the legacy `user-<peerName>` peer so previously accumulated memory is never orphaned on upgrade.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ OpenCode reads and writes this shared config file directly. OpenCode-specific de
       "aiPeer": "opencode",
       "recallMode": "hybrid",
       "sessionStrategy": "per-directory",
-      "removeUserPrefix": true // true uses the bare peerName; false (default on upgrade) keeps the legacy user-<peerName> peer
+      "removeUserPrefix": true, // true uses the bare peerName; false (default on upgrade) keeps the legacy user-<peerName> peer
+      "apiKey": "hch-..." // optional; overrides the root apiKey for this host
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ type HonchoSettings = {
 }
 
 type HostScopedSettings = Partial<
-  Pick<HonchoSettings, "workspace" | "aiPeer" | "recallMode" | "sessionStrategy" | "removeUserPrefix">
+  Pick<HonchoSettings, "apiKey" | "workspace" | "aiPeer" | "recallMode" | "sessionStrategy" | "removeUserPrefix">
 >
 
 type RuntimeHandle = {
@@ -380,7 +380,6 @@ const hostScopedSettings = (value: unknown): HostScopedSettings | null => {
     return null
   }
   const normalized = normalizedRawSettings(value)
-  delete normalized[LEGACY_API_KEY_FIELD]
   delete normalized.peerName
   delete normalized.linkedHosts
   delete normalized.baseUrl
@@ -1485,8 +1484,8 @@ export const createHonchoRuntimePlugin =
               }
 
               if (shouldPersistGlobal) {
-                if (effectiveApiKey) {
-                  nextGlobal[LEGACY_API_KEY_FIELD] = effectiveApiKey
+                if (providedApiKey) {
+                  nextGlobal[LEGACY_API_KEY_FIELD] = providedApiKey
                   persistedFields.push(LEGACY_API_KEY_FIELD)
                 }
                 nextGlobal.peerName = effectivePeerName
@@ -1500,7 +1499,8 @@ export const createHonchoRuntimePlugin =
                     baseUrl: effectiveBaseUrl,
                   },
                 )
-                nextHosts.opencode = hostDefaults(nextResolved)
+                const existingOpenCodeHost = isRecord(nextHosts.opencode) ? { ...nextHosts.opencode } : {}
+                nextHosts.opencode = { ...existingOpenCodeHost, ...hostDefaults(nextResolved) }
                 nextGlobal.hosts = nextHosts
                 if (providedBaseUrl || providedApiKey) {
                   persistedFields.push("baseUrl")

--- a/tests/honcho-setup.test.js
+++ b/tests/honcho-setup.test.js
@@ -743,3 +743,22 @@ test("bare peer colliding with the agent peer falls back to the prefix instead o
     expect(result.peers.userPeer.id).toBe("user-opencode")
   })
 })
+
+test("hosts.opencode.apiKey is used when the root apiKey is absent", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "honcho-host-key-root-"))
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "honcho-host-key-home-"))
+  await mkdir(path.join(homeDir, ".honcho"), { recursive: true })
+  const cfg = path.join(homeDir, ".honcho", "config.json")
+
+  await withEnv({ HOME: homeDir, USER: "ignored-user", XDG_CONFIG_HOME: undefined, HONCHO_API_KEY: undefined }, async () => {
+    await writeFile(cfg, JSON.stringify({
+      peerName: "alice",
+      baseUrl: "http://127.0.0.1:8000",
+      hosts: { opencode: { workspace: "opencode", aiPeer: "opencode", apiKey: "host-opencode-jwt" } },
+    }))
+    const hooks = await createPluginHarness(rootDir)
+    const env = { env: {} }
+    await hooks["shell.env"]({}, env)
+    expect(env.env.HONCHO_API_KEY).toBe("host-opencode-jwt")
+  })
+})


### PR DESCRIPTION
## Summary
- Stop stripping `hosts.opencode.apiKey` so a host-scoped token is used instead of only the root `apiKey` (fixes #33).
- Setup writes a root key only when one is provided, and merges host defaults onto the existing `hosts.opencode` block so a host key is not copied or dropped.
