### PR TITLE
docs: clarify prompt recall deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Inject memory through OpenCode hooks. The system prompt always carries the Honcho memory instruction; with `recallMode` `hybrid` or `context`, a stable memory snapshot is added once per session and prompt-specific recall is appended to each user turn. `tools` injects the instruction only. Recalled memory is presented as untrusted reference data.
+- Inject memory through OpenCode hooks. The system prompt always carries the Honcho memory instruction; with `recallMode` `hybrid` or `context`, a stable memory snapshot is added once per session and prompt-specific recall is retrieved for user turns, then appended when new (unchanged blocks are deduplicated within the session). `tools` injects the instruction only. Recalled memory is presented as untrusted reference data.
 - Record significant tool activity (shell commands, file edits, delegated tasks) to Honcho via `tool.execute.after`. Read-only and trivial calls are skipped; shell arguments that may carry credentials are redacted down to the executable name.
 - Ship a `honcho-memory` skill and install it to `~/.config/opencode/skills/honcho-memory` (or `$OPENCODE_CONFIG_DIR/skills/honcho-memory`) on session start and after setup. An unchanged file is left untouched.
 - Honor `hosts.opencode.apiKey` as an override of the root `apiKey`. Setup preserves a host-scoped key instead of copying or dropping it.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The plugin uses these OpenCode plugin capabilities:
 ### How hooks drive memory
 
 - `experimental.chat.system.transform` always appends the Honcho memory instruction. With `recallMode` `hybrid` or `context` it also adds a stable memory snapshot (user profile, agent context, session summary), captured once on the first turn of a session.
-- `chat.message` appends prompt-specific recall to each user turn in `hybrid` and `context` mode. In `tools` mode nothing beyond the instruction is injected; the model reaches memory only through the `honcho_*` tools.
+- `chat.message` retrieves prompt-specific recall on user turns in `hybrid` and `context` mode, appending a synthetic memory part when it yields a new block. Unchanged blocks are deduplicated within the session. In `tools` mode nothing beyond the instruction is injected; the model reaches memory only through the `honcho_*` tools.
 - `tool.execute.after` records shell commands, file edits, and delegated tasks to the session. Read-only and trivial calls are skipped. Shell arguments that may carry credentials are redacted, keeping only the executable name.
 - On session start and after `honcho_setup`, the packaged `honcho-memory` skill is copied to `~/.config/opencode/skills/honcho-memory`, or `$OPENCODE_CONFIG_DIR/skills/honcho-memory` when set. An unchanged file is left untouched.
 


### PR DESCRIPTION
Follow-up to #40. Clarifies that prompt-specific recall is retrieved on user turns and appended only when new; unchanged blocks are deduplicated within a session. Documentation only. Verification: git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented session-level deduplication for recalled memory blocks.
  - Clarified that prompt-specific recall is appended as a synthetic memory section only when it produces new content.
  - Repeated memory blocks are now documented as being avoided within the same session.
  - Clarified that tools mode includes the memory instruction and explicit memory tools only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->