### PR TITLE
fix: deduplicate concurrent session-start hydration with an in-flight guard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,10 @@ type SessionState = {
   // mid-session change to the system prompt.
   systemContext: string | null
   systemContextSealed: boolean
+  // Hydration currently running for this session. Concurrent triggers share
+  // this promise instead of each starting their own hydration. Cleared in
+  // finally so a failed hydration can be retried by the next trigger.
+  stableContextHydration: Promise<boolean> | null
   cachedPromptContext: string | null
   lastInjectedContext: string | null
   recentConclusions: string[]
@@ -1060,6 +1064,7 @@ const createSessionState = (): SessionState => ({
   stableContext: null,
   systemContext: null,
   systemContextSealed: false,
+  stableContextHydration: null,
   cachedPromptContext: null,
   lastInjectedContext: null,
   recentConclusions: [],
@@ -1384,6 +1389,18 @@ export const createHonchoRuntimePlugin =
       )
     }
 
+    const ensureStableContextHydration = async (runtime: ActiveRuntime, state: SessionState) => {
+      if (state.stableContext) {
+        return true
+      }
+      if (!state.stableContextHydration) {
+        state.stableContextHydration = hydrateSessionStartContext(runtime, state).finally(() => {
+          state.stableContextHydration = null
+        })
+      }
+      return state.stableContextHydration
+    }
+
     const refreshPromptContext = async (runtime: ActiveRuntime, state: SessionState, query: string) => {
       const topicKey = deriveTopicKey(query)
       if (!shouldRefreshPromptContext(state, topicKey, INTERNAL_CONTEXT_REFRESH)) {
@@ -1458,7 +1475,7 @@ export const createHonchoRuntimePlugin =
           void ensureHonchoSkillInstalled()
           await withRuntime(payload, async (runtime) => {
             const state = getState(deriveSessionStateKey(runtime))
-            await hydrateSessionStartContext(runtime, state)
+            await ensureStableContextHydration(runtime, state)
             await log("info", "Honcho session initialized for OpenCode.", await runtimeStatus(payload))
           }, undefined)
           return
@@ -1568,7 +1585,7 @@ export const createHonchoRuntimePlugin =
         if (!state.systemContextSealed) {
           if (!state.stableContext) {
             await withRuntime(input, async (runtime) => {
-              await hydrateSessionStartContext(runtime, state)
+              await ensureStableContextHydration(runtime, state)
             }, undefined)
           }
           state.systemContext = state.stableContext ?? ""

--- a/tests/context-injection.test.js
+++ b/tests/context-injection.test.js
@@ -243,6 +243,78 @@ test("system transform seals the stable context on the first turn", async () => 
   }
 })
 
+test("overlapping session.created and system.transform hydrations share one dialectic fan-out", async () => {
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+  const waitFor = async (predicate) => {
+    for (let i = 0; i < 50; i++) {
+      if (predicate()) return
+      await tick()
+    }
+  }
+
+  await runWithHarness(async ({ hooks, fetch }) => {
+    const chatCalls = () =>
+      fetch.calls.filter((call) => call.method === "POST" && /\/peers\/[^/]+\/chat$/.test(call.pathname))
+
+    // Defer the hydration chat responses so both triggers are guaranteed to
+    // start while the first hydration is still in flight.
+    const originalFetch = globalThis.fetch
+    const releases = []
+    globalThis.fetch = async (url, init) => {
+      const target = new URL(typeof url === "string" ? url : url.toString())
+      if (init?.method === "POST" && /\/peers\/[^/]+\/chat$/.test(target.pathname)) {
+        const started = fetch(url, init)
+        return new Promise((resolve) => releases.push(() => resolve(started)))
+      }
+      return fetch(url, init)
+    }
+    try {
+      const created = hooks.event({
+        event: { type: "session.created", properties: { sessionID: "ses-test" } },
+      })
+      await waitFor(() => chatCalls().length >= 2)
+
+      const output = { system: [] }
+      const transformed = hooks["experimental.chat.system.transform"](systemInput(), output)
+      await waitFor(() => chatCalls().length > 2 || output.system.length > 1)
+      for (let i = 0; i < 10; i++) {
+        await tick()
+      }
+
+      // Both triggers await one shared hydration (2 dialectic chat calls).
+      // Without the in-flight guard each trigger hydrates on its own
+      // (4 dialectic chat calls).
+      expect(chatCalls()).toHaveLength(2)
+      for (const release of releases.splice(0)) release()
+      await created
+      await transformed
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+test("failed hydration is retried by the next trigger instead of cached", async () => {
+  await runWithHarness(async ({ hooks, fetch }) => {
+    const chatCalls = () =>
+      fetch.calls.filter((call) => call.method === "POST" && /\/peers\/[^/]+\/chat$/.test(call.pathname))
+
+    await hooks.event({
+      event: { type: "session.created", properties: { sessionID: "ses-test" } },
+    })
+    expect(chatCalls()).toHaveLength(2)
+
+    const output = { system: [] }
+    await hooks["experimental.chat.system.transform"](systemInput(), output)
+
+    // Hydration failed completely, so nothing stable was sealed...
+    expect(output.system).toHaveLength(1)
+    // ...but the second trigger retried instead of inheriting the failed
+    // in-flight promise.
+    expect(chatCalls()).toHaveLength(4)
+  }, { failStableHydration: true })
+})
+
 test("chat.message skips recall for trivial prompt text", async () => {
   await runWithHarness(async ({ hooks, fetch }) => {
     const chatOutput = {


### PR DESCRIPTION
## Problem

On session start, two hooks can trigger stable-context hydration concurrently:\
the `session.created` event and the first `experimental.chat.system.transform`.\
Both check `!state.stableContext` before hydrating, but that flag is only set\
_after_ hydration completes — so a second trigger arriving while the first\
hydration is still in flight starts a full second hydration of its own.

Each hydration includes two dialectic peer chats (user + agent), so the\
duplicate fan-out doubles that work. Measured on a live fresh session with a\
stock setup:

|        | API calls (hydration) | tokens  |
| ------ | --------------------- | ------- |
| before | ~6                    | ~37,000 |
| after  | ~2                    | ~10,300 |

Follow-up turns are unaffected (no hydration calls either way).

## Fix

Track the in-flight hydration per session state instead of letting each\
trigger start its own:

* Add `SessionState.stableContextHydration: Promise&lt;boolean&gt; | null`.

* Add `ensureStableContextHydration()`: returns early when a stable context\
  already exists; otherwise starts hydration only if none is in flight and\
  returns the shared promise, so concurrent triggers await one hydration.

* The marker is cleared in `.finally()`, so a _failed_ hydration is retried\
  by the next trigger rather than cached.

* Both `session.created` and `system.transform` now go through the wrapper.

## Tests

Two regression tests in `tests/context-injection.test.js`:

1. **Overlapping triggers share one fan-out** — `session.created` and\
   `system.transform` are started while the first hydration is still in\
   flight (chat responses deferred within the test); asserts exactly 2\
   dialectic chat calls. Fails with 4 calls on unpatched `main`.

2. **Failed hydration is retried, not cached** — with hydration forced to\
   fail, the second trigger re-attempts instead of inheriting the failed\
   in-flight promise.

Full suite: 27 pass / 0 fail (25 existing + 2 new).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session context hydration to prevent duplicate concurrent requests.
  - Hydration now retries successfully after a failure instead of reusing a failed request.
  - Ensured system prompts and session creation use consistent, stable context hydration.

- **Tests**
  - Added coverage for concurrent hydration deduplication.
  - Added coverage confirming hydration can be retried after failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->